### PR TITLE
Declarations in protocol

### DIFF
--- a/src/main/scala/ru/tinkoff/gatling/amqp/AmqpDsl.scala
+++ b/src/main/scala/ru/tinkoff/gatling/amqp/AmqpDsl.scala
@@ -1,6 +1,6 @@
 package ru.tinkoff.gatling.amqp
 
-import com.rabbitmq.client.ConnectionFactory
+import com.rabbitmq.client.{BuiltinExchangeType, ConnectionFactory}
 import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Expression
@@ -11,7 +11,7 @@ import ru.tinkoff.gatling.amqp.request.{AmqpDslBuilderBase, PublishDslBuilder, R
 trait AmqpDsl extends AmqpCheckSupport {
   def amqp(implicit configuration: GatlingConfiguration): AmqpProtocolBuilderBase.type = AmqpProtocolBuilderBase
 
-  def amqp(requestName: Expression[String]) = AmqpDslBuilderBase(requestName)
+  def amqp(requestName: Expression[String]): AmqpDslBuilderBase = AmqpDslBuilderBase(requestName)
 
   def rabbitmq(implicit configuration: GatlingConfiguration): RabbitMQConnectionFactoryBuilderBase.type =
     RabbitMQConnectionFactoryBuilderBase
@@ -19,6 +19,19 @@ trait AmqpDsl extends AmqpCheckSupport {
   def rabbitReceiver(implicit configuration: GatlingConfiguration): RabbitMQConnectionFactoryBuilderBase.type =
     RabbitMQConnectionFactoryBuilderBase
 
+  def queue(name: String,
+            durable: Boolean = true,
+            exclusive: Boolean = false,
+            autoDelete: Boolean = true,
+            arguments: Map[String, Any] = Map.empty): AmqpQueue =
+    AmqpQueue(name, durable, exclusive, autoDelete, arguments)
+
+  def exchange(name: String,
+               exchangeType: BuiltinExchangeType,
+               durable: Boolean = true,
+               autoDelete: Boolean = true,
+               arguments: Map[String, Any] = Map.empty): AmqpExchange =
+    AmqpExchange(name, exchangeType, durable, autoDelete, arguments)
 
   implicit def amqpProtocolBuilder2amqpProtocol(builder: AmqpProtocolBuilder): AmqpProtocol = builder.build
 

--- a/src/main/scala/ru/tinkoff/gatling/amqp/client/AmqpPublisher.scala
+++ b/src/main/scala/ru/tinkoff/gatling/amqp/client/AmqpPublisher.scala
@@ -1,43 +1,30 @@
 package ru.tinkoff.gatling.amqp.client
 
 import io.gatling.core.session.Session
-import javax.jms.DeliveryMode
 import ru.tinkoff.gatling.amqp.action.Around
 import ru.tinkoff.gatling.amqp.protocol.AmqpComponents
-import ru.tinkoff.gatling.amqp.request.{AmqpDirectExchange, AmqpTopicExchange, AmqpExchange, AmqpProtocolMessage, AmqpQueueExchange}
+import ru.tinkoff.gatling.amqp.request._
 
-import scala.collection.JavaConverters._
 
 class AmqpPublisher(destination: AmqpExchange, components: AmqpComponents) extends WithAmqpChannel {
   def publish(message: AmqpProtocolMessage, around: Around, session: Session): Unit = {
 
-    val protocolDurable = components.protocol.deliveryMode == DeliveryMode.PERSISTENT
-
     destination match {
-      case AmqpDirectExchange(name, routingKey, durable) =>
+      case AmqpDirectExchange(name, routingKey, _) =>
         for {
           exName <- name(session)
           exKey  <- routingKey(session)
-        } withChannel { channel =>
-          channel.exchangeDeclare(exName, "direct", durable || protocolDurable)
-          around(channel.basicPublish(exName, exKey, message.amqpProperties, message.payload))
-        }
+        } withChannel(channel => around(channel.basicPublish(exName, exKey, message.amqpProperties, message.payload)))
 
-      case AmqpQueueExchange(name, durable) =>
+      case AmqpQueueExchange(name, _) =>
         name(session).foreach(qName =>
-          withChannel { channel =>
-            channel.queueDeclare(qName, durable || protocolDurable, false, false, Map.empty[String, Object].asJava)
-            around(channel.basicPublish("", qName, message.amqpProperties, message.payload))
-        })
+          withChannel(channel => around(channel.basicPublish("", qName, message.amqpProperties, message.payload))))
 
-      case AmqpTopicExchange(name, routingKey, durable) =>
+      case AmqpTopicExchange(name, routingKey, _) =>
         for {
           exName <- name(session)
           exKey  <- routingKey(session)
-        } withChannel { channel =>
-          channel.exchangeDeclare(exName, "topic", durable || protocolDurable)
-          around(channel.basicPublish(exName, exKey, message.amqpProperties, message.payload))
-        }
+        } withChannel(channel => around(channel.basicPublish(exName, exKey, message.amqpProperties, message.payload)))
     }
   }
 

--- a/src/main/scala/ru/tinkoff/gatling/amqp/protocol/AmqpProtocolBuilderBase.scala
+++ b/src/main/scala/ru/tinkoff/gatling/amqp/protocol/AmqpProtocolBuilderBase.scala
@@ -3,6 +3,8 @@ package ru.tinkoff.gatling.amqp.protocol
 import com.rabbitmq.client.ConnectionFactory
 
 case object AmqpProtocolBuilderBase {
-  def connectionFactory(cf: ConnectionFactory) = AmqpProtocolBuilder(cf, cf)
-  def connectionFactory(requestConnectionFactory: ConnectionFactory, replyConnectionFactory: ConnectionFactory) = AmqpProtocolBuilder(requestConnectionFactory, replyConnectionFactory)
+  def connectionFactory(cf: ConnectionFactory): AmqpProtocolBuilder = AmqpProtocolBuilder(cf, cf)
+  def connectionFactory(requestConnectionFactory: ConnectionFactory,
+                        replyConnectionFactory: ConnectionFactory): AmqpProtocolBuilder =
+    AmqpProtocolBuilder(requestConnectionFactory, replyConnectionFactory)
 }

--- a/src/test/scala/ru/tinkoff/gatling/amqp/examples/PublishExample.scala
+++ b/src/test/scala/ru/tinkoff/gatling/amqp/examples/PublishExample.scala
@@ -20,6 +20,7 @@ class PublishExample extends Simulation {
         .vhost("/")
     )
     .usePersistentDeliveryMode
+    .declare(queue("test_q_in"))
 
   val scn: ScenarioBuilder = scenario("AMQP test")
     .feed(idFeeder)

--- a/src/test/scala/ru/tinkoff/gatling/amqp/examples/RequestReplyExample.scala
+++ b/src/test/scala/ru/tinkoff/gatling/amqp/examples/RequestReplyExample.scala
@@ -1,8 +1,8 @@
 package ru.tinkoff.gatling.amqp.examples
 
+import com.rabbitmq.client.BuiltinExchangeType
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
-
 import ru.tinkoff.gatling.amqp.Predef._
 import ru.tinkoff.gatling.amqp.examples.Utils.idFeeder
 import ru.tinkoff.gatling.amqp.protocol.AmqpProtocolBuilder
@@ -10,6 +10,10 @@ import ru.tinkoff.gatling.amqp.protocol.AmqpProtocolBuilder
 import scala.concurrent.duration._
 
 class RequestReplyExample extends Simulation{
+  private val topic = exchange("test_queue_in", BuiltinExchangeType.TOPIC)
+  private val innerQ = queue("test_queue_inner_in")
+  private val outQueue = queue("test_queue_out")
+
   val amqpConf: AmqpProtocolBuilder = amqp
     .connectionFactory(
       rabbitmq
@@ -23,6 +27,10 @@ class RequestReplyExample extends Simulation{
     .consumerThreadsCount(8)
     .matchByMessageId
     .usePersistentDeliveryMode
+    .declare(topic)
+    .declare(innerQ)
+    .declare(outQueue)
+    .bindQueue(innerQ, topic, "we")
 
   val scn: ScenarioBuilder = scenario("AMQP test")
     .feed(idFeeder)


### PR DESCRIPTION
Exchanges and queues may be created before test. To make this possible, the protocol DSL were extended with new actions(declare, bind, queue, exchange). This is shown in more detail in the examples. This close #24.